### PR TITLE
1.0.1

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1845,16 +1845,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "5.6.5",
+            "version": "5.6.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "90614c73d3800e187615e2dd236ad0e2a01bf761"
+                "reference": "5cee1d3dfc2d2aa6599834520911d246f656bcb8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/90614c73d3800e187615e2dd236ad0e2a01bf761",
-                "reference": "90614c73d3800e187615e2dd236ad0e2a01bf761",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/5cee1d3dfc2d2aa6599834520911d246f656bcb8",
+                "reference": "5cee1d3dfc2d2aa6599834520911d246f656bcb8",
                 "shasum": ""
             },
             "require": {
@@ -1864,7 +1864,7 @@
                 "phpdocumentor/reflection-common": "^2.2",
                 "phpdocumentor/type-resolver": "^1.7",
                 "phpstan/phpdoc-parser": "^1.7|^2.0",
-                "webmozart/assert": "^1.9.1"
+                "webmozart/assert": "^1.9.1 || ^2"
             },
             "require-dev": {
                 "mockery/mockery": "~1.3.5 || ~1.6.0",
@@ -1903,9 +1903,9 @@
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
             "support": {
                 "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.6.5"
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.6.6"
             },
-            "time": "2025-11-27T19:50:05+00:00"
+            "time": "2025-12-22T21:13:58+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -2098,16 +2098,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "2.3.0",
+            "version": "2.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "1e0cd5370df5dd2e556a36b9c62f62e555870495"
+                "reference": "16dbf9937da8d4528ceb2145c9c7c0bd29e26374"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/1e0cd5370df5dd2e556a36b9c62f62e555870495",
-                "reference": "1e0cd5370df5dd2e556a36b9c62f62e555870495",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/16dbf9937da8d4528ceb2145c9c7c0bd29e26374",
+                "reference": "16dbf9937da8d4528ceb2145c9c7c0bd29e26374",
                 "shasum": ""
             },
             "require": {
@@ -2139,9 +2139,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.0"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.1"
             },
-            "time": "2025-08-30T15:50:23+00:00"
+            "time": "2026-01-12T11:33:04+00:00"
         },
         {
             "name": "phpstan/phpstan",
@@ -2739,16 +2739,16 @@
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v6.4.30",
+            "version": "v6.4.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "5328f994cbb0855ba25c3a54f4a31a279511640f"
+                "reference": "10058832a74a33648870aa2057e3fdc8796a6566"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/5328f994cbb0855ba25c3a54f4a31a279511640f",
-                "reference": "5328f994cbb0855ba25c3a54f4a31a279511640f",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/10058832a74a33648870aa2057e3fdc8796a6566",
+                "reference": "10058832a74a33648870aa2057e3fdc8796a6566",
                 "shasum": ""
             },
             "require": {
@@ -2800,7 +2800,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v6.4.30"
+                "source": "https://github.com/symfony/dependency-injection/tree/v6.4.31"
             },
             "funding": [
                 {
@@ -2820,7 +2820,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-07T09:29:59+00:00"
+            "time": "2025-12-23T13:34:50+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",

--- a/includes/Optimizations/Image/Converters/Avif_Converter.php
+++ b/includes/Optimizations/Image/Converters/Avif_Converter.php
@@ -186,7 +186,7 @@ class Avif_Converter implements Converter {
         );
 
         $destination_path = sprintf(
-            '%s/%s%s.%s',
+            '%s/%s_%s.%s',
             $path_info['dirname'],
             $path_info['filename'],
             $suffix,
@@ -194,7 +194,7 @@ class Avif_Converter implements Converter {
         );
 
         $destination_url = sprintf(
-            '%s%s.%s',
+            '%s_%s.%s',
             preg_replace( '/\.[^.]+$/', '', $this->image->get_url() ),
             $suffix,
             self::EXTENSION

--- a/includes/Optimizations/Image/Converters/Avif_Converter.php
+++ b/includes/Optimizations/Image/Converters/Avif_Converter.php
@@ -116,6 +116,56 @@ class Avif_Converter implements Converter {
     }
 
     /**
+     * Return a unique filename suffix to avoid overwriting existing files.
+     *
+     * @throws Image_Conversion_Exception If a unique filename could not be generated after multiple attempts.
+     *
+     * @param string $dir_name  Directory name.
+     * @param string $filename  Filename without extension.
+     * @param string $extension File extension.
+     *
+     * @return string
+     */
+    private function get_unique_suffix( string $dir_name, string $filename, string $extension ): string {
+        $base_suffix = 'optimized';
+        $suffix      = $base_suffix;
+
+        // Initial destination path
+        $destination_path = sprintf(
+            '%s/%s%s.%s',
+            $dir_name,
+            $filename,
+            $suffix,
+            $extension
+        );
+
+        $max_attempts = 5;
+        $counter      = 1;
+
+        while ( file_exists( $destination_path ) ) {
+            $suffix = sprintf( '%s_%d', $base_suffix, $counter );
+
+            $destination_path = sprintf(
+                '%s/%s%s.%s',
+                $dir_name,
+                $filename,
+                $suffix,
+                $extension
+            );
+
+            ++$counter;
+
+            if ( $counter > $max_attempts ) {
+                throw new Image_Conversion_Exception(
+                    'Could not generate a unique filename for the converted image.'
+                );
+            }
+        }
+
+        return $suffix;
+    }
+
+    /**
      * Convert the specified image.
      *
      * @throws Image_Conversion_Exception If no image is loaded.
@@ -128,17 +178,25 @@ class Avif_Converter implements Converter {
             throw new Image_Conversion_Exception( 'Image is not loaded' );
         }
 
-        $destination_url = sprintf(
-            '%s.%s',
-            preg_replace( '/\.[^.]+$/', '', $this->image->get_url() ),
+        $path_info = pathinfo( $this->image->get_path() );
+        $suffix    = $this->get_unique_suffix(
+            $path_info['dirname'],
+            $path_info['filename'],
             self::EXTENSION
         );
 
-        $path_info        = pathinfo( $this->image->get_path() );
         $destination_path = sprintf(
-            '%s/%s.%s',
+            '%s/%s%s.%s',
             $path_info['dirname'],
             $path_info['filename'],
+            $suffix,
+            self::EXTENSION
+        );
+
+        $destination_url = sprintf(
+            '%s%s.%s',
+            preg_replace( '/\.[^.]+$/', '', $this->image->get_url() ),
+            $suffix,
             self::EXTENSION
         );
 

--- a/includes/Optimizations/Image/Converters/Webp_Converter.php
+++ b/includes/Optimizations/Image/Converters/Webp_Converter.php
@@ -186,7 +186,7 @@ class Webp_Converter implements Converter {
         );
 
         $destination_path = sprintf(
-            '%s/%s%s.%s',
+            '%s/%s_%s.%s',
             $path_info['dirname'],
             $path_info['filename'],
             $suffix,
@@ -194,7 +194,7 @@ class Webp_Converter implements Converter {
         );
 
         $destination_url = sprintf(
-            '%s%s.%s',
+            '%s_%s.%s',
             preg_replace( '/\.[^.]+$/', '', $this->image->get_url() ),
             $suffix,
             self::EXTENSION

--- a/includes/Optimizations/Image/Image_Metadata_Manager.php
+++ b/includes/Optimizations/Image/Image_Metadata_Manager.php
@@ -8,6 +8,8 @@
 
 namespace Pressidium\WP\Performance\Optimizations\Image;
 
+use Pressidium\WP\Performance\Utils\String_Utils;
+
 if ( ! defined( 'ABSPATH' ) ) {
     die( 'Forbidden' );
 }
@@ -64,7 +66,7 @@ class Image_Metadata_Manager {
         $relative_path = $this->ensure_path_is_relative( $optimized_image->get_path() );
 
         if ( $size_variant_name === 'full' ) {
-            $metadata['file']         = $relative_path;
+            $metadata['file']         = String_Utils::unleading_slash_it( $relative_path );
             $metadata['filesize']     = filesize( $optimized_image->get_path() );
             $metadata['mime-type']    = $optimized_image->get_mime_type();
             $metadata['is_optimized'] = true;

--- a/includes/Optimizations/Image/Original_Files_Deletion_Manager.php
+++ b/includes/Optimizations/Image/Original_Files_Deletion_Manager.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * Original files deletion manager.
+ *
+ * @author Konstantinos Pappas <konpap@pressidium.com>
+ * @copyright 2026 Pressidium
+ */
+
+namespace Pressidium\WP\Performance\Optimizations\Image;
+
+use Pressidium\WP\Performance\Files\Filesystem;
+use Pressidium\WP\Performance\Hooks\Actions;
+use Pressidium\WP\Performance\Logging\Logger;
+use Pressidium\WP\Performance\Utils\String_Utils;
+
+use WP_Post;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    die( 'Forbidden' );
+}
+
+/**
+ * Original_Files_Deletion_Manager class.
+ *
+ * @since 1.0.0
+ */
+class Original_Files_Deletion_Manager implements Actions {
+
+    /**
+     * Original_Files_Deletion_Manager constructor.
+     *
+     * @param Logger     $logger     Logger.
+     * @param Filesystem $filesystem Filesystem.
+     */
+    public function __construct( private readonly Logger $logger, private readonly Filesystem $filesystem ) {}
+
+    /**
+     * Return metadata for the attachment with the given attachment ID.
+     *
+     * @param int $post_id Attachment ID.
+     *
+     * @return array{
+     *    width?: int,
+     *    height?: int,
+     *    file?: string,
+     *    sizes?: array<string, array{file?: string, width?: int, height?: int, "mime-type"?: string, filesize?: int}>,
+     *    image_meta?: array,
+     *    filesize?: int,
+     *    is_optimized?: bool,
+     *    original?: array
+     *  }|false
+     */
+    private function get_attachment_metadata( int $post_id ): array|false {
+        return wp_get_attachment_metadata( $post_id );
+    }
+
+    /**
+     * Whether the attachment has been optimized.
+     *
+     * @param array $metadata Attachment metadata.
+     *
+     * @return bool
+     */
+    private function is_optimized( array $metadata ): bool {
+        if ( ! isset( $metadata['is_optimized'] ) ) {
+            return false;
+        }
+
+        $flag = $metadata['is_optimized'];
+
+        return $flag === true || $flag === 1 || $flag === '1' || $flag === 'true';
+    }
+
+    /**
+     * Delete a file from the `uploads` directory.
+     *
+     * @param string $uploads_base_dir  Base `uploads` directory.
+     * @param string $original_base_dir Base directory of the original file.
+     * @param string $filename          Filename to delete.
+     *
+     * @return void
+     */
+    private function delete_file( string $uploads_base_dir, string $original_base_dir, string $filename ): void {
+        $file_path = sprintf(
+            '%s/%s/%s',
+            $uploads_base_dir,
+            $original_base_dir,
+            basename( $filename )
+        );
+
+        $this->logger->debug( sprintf( 'Deleting original file %s', esc_html( $file_path ) ) );
+
+        $this->filesystem->delete_file( $file_path );
+    }
+
+    /**
+     * Delete size variations of the original image.
+     *
+     * @param string $uploads_base_dir  Base `uploads` directory.
+     * @param string $original_base_dir Base directory of the original file.
+     * @param array<string, array{
+     *     file?: string,
+     *     width?: int,
+     *     height?: int,
+     *     "mime-type"?: string,
+     *     filesize?: int
+     * }> $original_sizes Size variations of the original image.
+     *                    Keys are size slugs, values are arrays
+     *                    which may contain:
+     *                    - `file`: Filename of the size variation.
+     *                    - `width`: Width of the size variation.
+     *                    - `height`: Height of the size variation.
+     *                    - `mime-type`: Mime type of the size variation.
+     *                    - `filesize`: File size of the size variation.
+     *
+     * @return void
+     */
+    private function delete_size_variations(
+        string $uploads_base_dir,
+        string $original_base_dir,
+        array $original_sizes
+    ): void {
+        foreach ( $original_sizes as $original_size ) {
+            $variant_filename = $original_size['file'] ?? null;
+
+            if ( empty( $variant_filename ) ) {
+                // No filename for this size variant, skip
+                continue;
+            }
+
+            $this->delete_file( $uploads_base_dir, $original_base_dir, $variant_filename );
+        }
+    }
+
+    /**
+     * Delete the original files when an optimized attachment is deleted.
+     *
+     * @link https://developer.wordpress.org/reference/hooks/delete_attachment/
+     *
+     * This method is called before the attachment is deleted from the database.
+     *
+     * @param int     $post_id Attachment ID.
+     * @param WP_Post $post    Attachment post object.
+     *
+     * @return void
+     */
+    public function delete_original_files( int $post_id, WP_Post $post ): void {
+        $metadata = $this->get_attachment_metadata( $post_id );
+
+        if ( ! $metadata ) {
+            return;
+        }
+
+        if ( ! $this->is_optimized( $metadata ) ) {
+            return;
+        }
+
+        $uploads_base_dir = String_Utils::untrailing_slash_it( wp_get_upload_dir()['basedir'] );
+
+        $original_file     = $metadata['original']['file'] ?? null;
+        $original_base_dir = String_Utils::unleading_slash_it( dirname( $original_file ?? '' ) );
+
+        $this->logger->debug( sprintf( 'Deleting original files for attachment ID %d', esc_html( $post_id ) ) );
+
+        if ( ! empty( $original_file ) ) {
+            $this->delete_file( $uploads_base_dir, $original_base_dir, $original_file );
+        }
+
+        $original_sizes = $metadata['original']['sizes'] ?? array();
+
+        $this->delete_size_variations( $uploads_base_dir, $original_base_dir, $original_sizes );
+    }
+
+    /**
+     * Return the actions to register.
+     *
+     * @return array<string, array{0: string, 1?: int, 2?: int}>
+     */
+    public function get_actions(): array {
+        return array(
+            'delete_attachment' => array( 'delete_original_files', 10, 2 ),
+        );
+    }
+
+}

--- a/includes/Optimizations/Image/Service_Provider.php
+++ b/includes/Optimizations/Image/Service_Provider.php
@@ -32,6 +32,7 @@ final class Service_Provider extends AbstractServiceProvider {
     protected $provides = array(
         'media_library',
         'image_optimization_manager',
+        'original_files_deletion_manager',
     );
 
     /**
@@ -57,6 +58,10 @@ final class Service_Provider extends AbstractServiceProvider {
              ->addArgument( $this->getContainer()->get( 'converter_manager' ) )
              ->addArgument( new Image_Metadata_Manager() )
              ->addArgument( new Posts_Updater() );
+
+        $this->getContainer()->add( 'original_files_deletion_manager', Original_Files_Deletion_Manager::class )
+             ->addArgument( $this->getContainer()->get( 'logger' ) )
+             ->addArgument( $this->getContainer()->get( 'filesystem' ) );
     }
 
 }

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -110,6 +110,7 @@ final class Plugin {
             $hooks_manager->register( $container->get( 'background_processes_api' ) );
             $hooks_manager->register( $container->get( 'optimization_api' ) );
             $hooks_manager->register( $container->get( 'image_optimization_manager' ) );
+            $hooks_manager->register( $container->get( 'original_files_deletion_manager' ) );
             $hooks_manager->register( $container->get( 'feedback' ) );
 
         } catch ( ContainerExceptionInterface | NotFoundExceptionInterface $exception ) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pressidium-performance",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pressidium-performance",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@wordpress/api-fetch": "^7.19.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pressidium-performance",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Speed up your WordPress site, improve Core Web Vitals and enhance user experience with one-click image optimization, CSS & JavaScript minification.",
   "main": "src/index.js",
   "scripts": {

--- a/pressidium-performance.php
+++ b/pressidium-performance.php
@@ -3,7 +3,7 @@
  * Plugin Name: Pressidium Performance
  * Plugin URI: https://pressidium.com/open-source/performance-plugin/
  * Description: Speed up your WordPress site, improve Core Web Vitals and enhance user experience with one-click image optimization, CSS & JavaScript minification.
- * Version: 1.0.0
+ * Version: 1.0.1
  * Author: Pressidium®
  * Author URI: https://pressidium.com/
  * Text Domain: pressidium-performance
@@ -27,7 +27,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 function setup_constants(): void {
     if ( ! defined( 'Pressidium\WP\Performance\VERSION' ) ) {
-        define( 'Pressidium\WP\Performance\VERSION', '1.0.0' );
+        define( 'Pressidium\WP\Performance\VERSION', '1.0.1' );
     }
 
     if ( ! defined( 'Pressidium\WP\Performance\PLUGIN_DIR' ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Tags: performance, optimizations, image optimization, convert webp, convert avif
 Requires at least: 6.9
 Tested up to: 6.9
 Requires PHP: 8.1
-Stable Tag: 1.0.0
+Stable Tag: 1.0.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -156,6 +156,10 @@ If you have spotted any bugs, or would like to request additional features from 
 7. Monitor every optimization task running behind the scenes.
 
 == Changelog ==
+
+= 1.0.1: Jan 15, 2026 =
+
+* Fix an issue where original images were overwritten when the source and target formats were the same
 
 = 1.0.0: Jan 9, 2026 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -157,9 +157,11 @@ If you have spotted any bugs, or would like to request additional features from 
 
 == Changelog ==
 
-= 1.0.1: Jan 15, 2026 =
+= 1.0.1: Jan 16, 2026 =
 
 * Fix an issue where original images were overwritten when the source and target formats were the same
+* Fix an issue where original images remained on the filesystem as orphaned files when optimized images were deleted from the Media Library
+* Fix an issue where optimizing images resulted in double slashes in `srcset` attributes
 
 = 1.0.0: Jan 9, 2026 =
 

--- a/uninstall.php
+++ b/uninstall.php
@@ -106,7 +106,7 @@ function pressidium_performance_uninstall(): void {
             $posts_updater->revert_posts( $metadata['file'], $original_metadata['file'] );
 
             // Delete the optimized image file from the filesystem
-            $optimized_image_path = $upload_dir . $metadata['file'];
+            $optimized_image_path = $upload_dir . DIRECTORY_SEPARATOR . $metadata['file'];
 
             if ( is_file( $optimized_image_path ) ) {
                 wp_delete_file( $optimized_image_path );


### PR DESCRIPTION
* Fix an issue where original images were overwritten when the source and target formats were the same
* Fix an issue where original images remained on the filesystem as orphaned files when optimized images were deleted from the Media Library
* Fix an issue where optimizing images resulted in double slashes in `srcset` attributes